### PR TITLE
hide calc

### DIFF
--- a/src/pages/calculator.js
+++ b/src/pages/calculator.js
@@ -294,7 +294,7 @@ class Calculator extends React.Component {
         <Disclaimer />
         <br />
         <br />
-        {this.state.showSection
+        {/* {this.state.showSection
           ? (
             <h4>
               Enter your information below to determine how much money
@@ -304,7 +304,7 @@ class Calculator extends React.Component {
             <PrimaryButton2 style={{ width: '100%' }} onClick={() => this.setState({ showSection: true })}>
               Did your rent increase on or after January 1st, 2020?
             </PrimaryButton2>
-          )}
+          )} */}
         <br />
         {this.state.showSection
           && (


### PR DESCRIPTION
> Hi! I updated the wireframe: https://xd.adobe.com/view/643f5f9f-4289-47ca-5c6c-1c91054ace8a-120e/. @reidjs, I spoke with our partners yesterday and we decided that for V1, it'd be best to take out the part about "did you rent increase after January 1st.." because they realized that they need to clarify for themselves on whether the 12-month period of a new rent increase would go from the month of increase or January 1st 2020. (i.e. if your rent was 1k on march 15th but your rent increased to 2k on July 1st, 2019, would the allowable rent of $1090 be valid until July 1st, 2020 or January 1st, 2021?) We'll add in that part for V2. The new layout is reflected in the wireframe.
-- Carmen