### PR TITLE
WIP: Make contact form components better

### DIFF
--- a/src/components/AutoSubmit.js
+++ b/src/components/AutoSubmit.js
@@ -1,0 +1,72 @@
+import React from "react";
+import AppContext from "./AppContext";
+
+const encode = (data) => {
+    return Object.keys(data)
+        .map(key => encodeURIComponent(key) + "=" + encodeURIComponent(data[key]))
+        .join("&");
+};
+
+const AutoSubmit = () => {
+    const submitForm = (appCtx) => {
+        if (appCtx.includeDetails) {
+
+            const values = {
+                firstName: appCtx.firstName, 
+                lastName: appCtx.lastName, 
+                email: appCtx.email, 
+                cell: appCtx.cell,
+                tenancyDuration: appCtx.tenancyDuration,
+                inEligibleType: appCtx.inEligibleType,
+                vouchers: appCtx.vouchers,
+                buildingAge: appCtx.buildingAge,
+                sharedKitchenOrBath: appCtx.sharedKitchenOrBath,
+                atLeast4Units: appCtx.atLeast4Units,
+                condo: appCtx.condo,
+                bizOwner: appCtx.bizOwner,
+                exmpetionNotice: appCtx.exmpetionNotice,
+                sfh: appCtx.sfh,
+                landlordShare: appCtx.landlordShare,
+                duplex: appCtx.duplex,
+                sharedDuplex: appCtx.sharedDuplex,
+                sharedUnitWithLandlord: appCtx.sharedUnitWithLandlord
+            }
+            fetch("/", {
+                method: "POST",
+                headers: { "Content-Type": "application/x-www-form-urlencoded" },
+                body: encode({ "form-name": "eligibiltyAnswers", ...values })
+            })
+
+                .catch(error => console.log(error));
+
+        }
+
+    };
+
+    return (
+        <AppContext.Consumer>
+            {({ appCtx, updateContext }) => (
+                <form  name="eligibiltyAnswers" data-netlify="true" data-netlify-honeypot="bot-field">
+                    <input type="hidden" name="form-name" value="eligibiltyAnswers" />
+                    <input type="hidden" name="tenancyDuration" value={appCtx.tenancyDuration} />
+                    <input type="hidden" name="inEligibleType" value={appCtx.inEligibleType} />
+                    <input type="hidden" name="vouchers" value={appCtx.vouchers} />
+                    <input type="hidden" name="buildingAge" value={appCtx.buildingAge} />
+                    <input type="hidden" name="sharedKitchenOrBath" value={appCtx.sharedKitchenOrBath} />
+                    <input type="hidden" name="atLeast4Units" value={appCtx.atLeast4Units} />
+                    <input type="hidden" name="condo" value={appCtx.condo} />
+                    <input type="hidden" name="bizOwner" value={appCtx.bizOwner} />
+                    <input type="hidden" name="exmpetionNotice" value={appCtx.exmpetionNotice} />
+                    <input type="hidden" name="sfh" value={appCtx.sfh} />
+                    <input type="hidden" name="landlordShare" value={appCtx.landlordShare} />
+                    <input type="hidden" name="duplex" value={appCtx.duplex} />
+                    <input type="hidden" name="sharedDuplex" value={appCtx.sharedDuplex} />
+                    <input type="hidden" name="sharedUnitWithLandlord" value={appCtx.sharedUnitWithLandlord} />
+                    {submitForm(appCtx)}
+                </form>
+            )}
+        </AppContext.Consumer>
+    );
+};
+
+export default AutoSubmit;

--- a/src/components/AutoSubmit.js
+++ b/src/components/AutoSubmit.js
@@ -7,38 +7,45 @@ const encode = (data) => {
         .join("&");
 };
 
-const AutoSubmit = () => {
-    const submitForm = (appCtx) => {
-        if (appCtx.includeDetails) {
+const AutoSubmit = ({ pageName }) => {
+    const submitForm = (appCtx, updateContext) => {
+        // TODO (tomc) figure out how to submit both calc and eligibilty exactly once
+        pageName = pageName ? pageName : 'autoSubmit';
+
+        if (appCtx.includeDetails && !appCtx[pageName]) {
 
             const values = {
                 firstName: appCtx.firstName, 
                 lastName: appCtx.lastName, 
                 email: appCtx.email, 
                 cell: appCtx.cell,
-                tenancyDuration: appCtx.tenancyDuration,
-                inEligibleType: appCtx.inEligibleType,
-                vouchers: appCtx.vouchers,
-                buildingAge: appCtx.buildingAge,
+                ab1482TenancyDuration: appCtx.ab1482TenancyDuration,
+                ineligibleType: appCtx.ineligibleType,
+                voucher: appCtx.voucher,
+                builtBefore2005: appCtx.builtBefore2005,
                 sharedKitchenOrBath: appCtx.sharedKitchenOrBath,
                 atLeast4Units: appCtx.atLeast4Units,
                 condo: appCtx.condo,
                 bizOwner: appCtx.bizOwner,
                 exmpetionNotice: appCtx.exmpetionNotice,
                 sfh: appCtx.sfh,
-                landlordShare: appCtx.landlordShare,
+                shareWithLandlord: appCtx.shareWithLandlord,
                 duplex: appCtx.duplex,
                 sharedDuplex: appCtx.sharedDuplex,
-                sharedUnitWithLandlord: appCtx.sharedUnitWithLandlord
+                sharedUnitWithLandlord: appCtx.sharedUnitWithLandlord,
+                lang: appCtx.lang
             }
             fetch("/", {
                 method: "POST",
                 headers: { "Content-Type": "application/x-www-form-urlencoded" },
                 body: encode({ "form-name": "eligibiltyAnswers", ...values })
-            })
-
-                .catch(error => console.log(error));
-
+            }).then(()=>{
+                var newCtx = {};
+                newCtx[pageName] = true;
+                updateContext( { appCtx, ...newCtx });
+                console.log(values);
+            }).catch(error => console.log(error));
+            
         }
 
     };
@@ -48,21 +55,22 @@ const AutoSubmit = () => {
             {({ appCtx, updateContext }) => (
                 <form  name="eligibiltyAnswers" data-netlify="true" data-netlify-honeypot="bot-field">
                     <input type="hidden" name="form-name" value="eligibiltyAnswers" />
-                    <input type="hidden" name="tenancyDuration" value={appCtx.tenancyDuration} />
-                    <input type="hidden" name="inEligibleType" value={appCtx.inEligibleType} />
-                    <input type="hidden" name="vouchers" value={appCtx.vouchers} />
-                    <input type="hidden" name="buildingAge" value={appCtx.buildingAge} />
+                    <input type="hidden" name="ab1482TenancyDuration" value={appCtx.ab1482TenancyDuration} />
+                    <input type="hidden" name="ineligibleType" value={appCtx.ineligibleType} />
+                    <input type="hidden" name="voucher" value={appCtx.voucher} />
+                    <input type="hidden" name="builtBefore2005" value={appCtx.builtBefore2005} />
                     <input type="hidden" name="sharedKitchenOrBath" value={appCtx.sharedKitchenOrBath} />
                     <input type="hidden" name="atLeast4Units" value={appCtx.atLeast4Units} />
                     <input type="hidden" name="condo" value={appCtx.condo} />
                     <input type="hidden" name="bizOwner" value={appCtx.bizOwner} />
                     <input type="hidden" name="exmpetionNotice" value={appCtx.exmpetionNotice} />
                     <input type="hidden" name="sfh" value={appCtx.sfh} />
-                    <input type="hidden" name="landlordShare" value={appCtx.landlordShare} />
+                    <input type="hidden" name="shareWithLandlord" value={appCtx.shareWithLandlord} />
                     <input type="hidden" name="duplex" value={appCtx.duplex} />
                     <input type="hidden" name="sharedDuplex" value={appCtx.sharedDuplex} />
                     <input type="hidden" name="sharedUnitWithLandlord" value={appCtx.sharedUnitWithLandlord} />
-                    {submitForm(appCtx)}
+                    <input type="hidden" name="lang" value={appCtx.lang} />
+                    {submitForm(appCtx, updateContext)}
                 </form>
             )}
         </AppContext.Consumer>

--- a/src/components/Contact.js
+++ b/src/components/Contact.js
@@ -2,6 +2,8 @@ import React from "react";
 import AppContext from "./AppContext"
 import { navigate } from "gatsby";
 
+import '../styles/contact.scss'
+
 const encode = (data) => {
     return Object.keys(data)
         .map(key => encodeURIComponent(key) + "=" + encodeURIComponent(data[key]))
@@ -16,8 +18,8 @@ var contactDict = {
         contactLegend: "Contact Information",
         email: "Email",
         cell: "Cell",
-        includeDetails: "Send details I enter about my tenancy",
-        disclaimer: "Any information you send is kept confidential and is only used to assist you with your case.",
+        includeDetails: "Share information I enter about my tenancy",
+        disclaimer: "Any information you share is kept confidential and is only used to assist you with your case.",
         submitText: "Connect with us",
     },
     es: {
@@ -27,8 +29,8 @@ var contactDict = {
         contactLegend: "Información del contacto",
         email: "Correo Electrónico",
         cell: "Celular",
-        includeDetails: "Incluya detalles que ingrese sobre mi arrendamiento",
-        disclaimer: "Cualquier información que envíe se mantiene confidencial y solo se utiliza para ayudarlo con su caso.",
+        includeDetails: "Compartir información que ingreso sobre mi arrendamiento",
+        disclaimer: "Cualquier información que comparta se mantiene confidencial y solo se utiliza para ayudarlo con su caso.",
         submitText: "Conéctate con nosotros",
     }
 };
@@ -92,22 +94,20 @@ class QuickContactForm extends React.Component {
                                 <input type="hidden" name="form-name" value="testQuickContact" />
                                 <fieldset>
                                     <legend>{dict[appCtx.lang].nameLegend}</legend>
-                                    <input type="text" name="firstName" value={firstName} onChange={this.handleChange} placeholder={dict[appCtx.lang].firstName} />&nbsp;
-                                    <input type="text" name="lastName" value={lastName} onChange={this.handleChange} placeholder={dict[appCtx.lang].lastName} />
+                                    <input className="form-control" type="text" name="firstName" value={firstName} onChange={this.handleChange} placeholder={dict[appCtx.lang].firstName} />
+                                    <input className="form-control" type="text" name="lastName" value={lastName} onChange={this.handleChange} placeholder={dict[appCtx.lang].lastName} />
                                 </fieldset>
                                 <fieldset>
                                     <legend>{dict[appCtx.lang].contactLegend}</legend>
-                                    <input type="tel" name="cell" value={cell} onChange={this.handleChange} placeholder={dict[appCtx.lang].cell} />&nbsp;
-                                    <input type="email" name="email" value={email} onChange={this.handleChange} placeholder={dict[appCtx.lang].email} />
+                                    <input className="form-control" type="tel" name="cell" value={cell} onChange={this.handleChange} placeholder={dict[appCtx.lang].cell} />
+                                    <input className="form-control" type="email" name="email" value={email} onChange={this.handleChange} placeholder={dict[appCtx.lang].email} />
                                 </fieldset>
                                 <fieldset>
-                                <fieldset>
-                                    <label><input type="checkbox" name="includeDetails" checked={includeDetails} onChange={this.handleChange} /> {dict[appCtx.lang].includeDetails}</label>
-                                    <p>{dict[appCtx.lang].disclaimer}</p>
+                                    <label className="form-control"><input type="checkbox" name="includeDetails" checked={includeDetails} onChange={this.handleChange} /> {dict[appCtx.lang].includeDetails}</label>
                                 </fieldset>
+                                <p className="disclaimer">{dict[appCtx.lang].disclaimer}</p>
                                 
                                 <button type="submit">{submitText ? submitText : dict[appCtx.lang].submitText}</button>
-                                </fieldset>
                             </form>
                         </div>
                         :

--- a/src/components/Contact.js
+++ b/src/components/Contact.js
@@ -60,8 +60,8 @@ class QuickContactForm extends React.Component {
         })
             .then(() => {
                 const quickFormSubmit = true;
-                const includeDetails = this.state.includeDetails;
-                updateContext({ quickFormSubmit, includeDetails });
+                const { includeDetails, firstName, lastName, email, cell } = this.state;
+                updateContext({ quickFormSubmit, includeDetails, firstName, lastName, email, cell });
 
                 if (this.state.submitDestination) {
                     navigate(this.state.submitDestination);

--- a/src/components/Contact.js
+++ b/src/components/Contact.js
@@ -90,8 +90,8 @@ class QuickContactForm extends React.Component {
                 {({ appCtx, updateContext }) => (
                     (!appCtx.quickFormSubmit || !autohide) ?
                         <div>
-                            <form onSubmit={(e) => { this.handleSubmit(e, updateContext) }} name="testQuickContact" data-netlify="true" data-netlify-honeypot="bot-field">
-                                <input type="hidden" name="form-name" value="testQuickContact" />
+                            <form onSubmit={(e) => { this.handleSubmit(e, updateContext) }} name="quickContact" data-netlify="true" data-netlify-honeypot="bot-field">
+                                <input type="hidden" name="form-name" value="quickContact" />
                                 <fieldset>
                                     <legend>{dict[appCtx.lang].nameLegend}</legend>
                                     <input className="form-control" type="text" name="firstName" value={firstName} onChange={this.handleChange} placeholder={dict[appCtx.lang].firstName} />

--- a/src/components/Zip.js
+++ b/src/components/Zip.js
@@ -8,11 +8,9 @@ class Zip extends React.Component {
     this.state = {
       zip: ""
     };
-    console.log(zipDB);
   }
 
   onChange = (newZip, appCtx, updateContext) => {
-    console.log(zipDB);
     // only allow digits
     if (!/\d+/.test(newZip.substr(newZip.length - 1, newZip.length))) {
       newZip = newZip.substr(0, newZip.length - 1);

--- a/src/components/contactACCE.js
+++ b/src/components/contactACCE.js
@@ -55,7 +55,7 @@ class QuickContactForm extends React.Component {
                     !appCtx.quickFormSubmit ?
                         <div>
                             <form onSubmit={(e) => { this.handleSubmit(e, updateContext) }} name="testContact" data-netlify="true" data-netlify-honeypot="bot-field">
-                                <input type="hidden" name="form-name" value="testContact" />
+                                <input type="hidden" name="form-name" value="testQuickContact" />
                                 <p>
                                     <label>
                                         Given name: <input type="text" name="givenName" value={givenName} onChange={this.handleChange} />&nbsp;
@@ -132,7 +132,7 @@ class FullContactForm extends React.Component {
             <AppContext.Consumer>
                 {({ appCtx, updateContext }) => (
                     <form onSubmit={this.handleSubmit} name="testContact" data-netlify="true" data-netlify-honeypot="bot-field">
-                        <input type="hidden" name="form-name" value="testContact" />
+                        <input type="hidden" name="form-name" value="testFullContact" />
                         <p>
                             <label>
                                 Given name: <input type="text" name="givenName" value={givenName} onChange={this.handleChange} />&nbsp;

--- a/src/components/contactACCE.js
+++ b/src/components/contactACCE.js
@@ -116,7 +116,7 @@ class FullContactForm extends React.Component {
         e.preventDefault();
     };
 
-    checkBoxes = { "rentIncrease": true, "eviction": true, "landlordOther": true, "understandRights": true, "fightForRights": true , contactCall: true, contactEmail: true, contactTxt: true};
+    checkBoxes = { "rentIncrease": true, "eviction": true, "landlordOther": true, "understandRights": true, "fightForRights": true , "contactCall": true, "contactEmail": true, "contactTxt": true};
 
     handleChange = e => {
         var value = e.target.value;
@@ -135,10 +135,10 @@ class FullContactForm extends React.Component {
                         <input type="hidden" name="form-name" value="testFullContact" />
                         <p>
                             <label>
-                                Given name: <input type="text" name="givenName" value={givenName} onChange={this.handleChange} />&nbsp;
+                                First: <input type="text" name="firstName" value={givenName} onChange={this.handleChange} />&nbsp;
                     </label>
                             <label>
-                                Family name: <input type="text" name="familyName" value={familyName} onChange={this.handleChange} />
+                                Last: <input type="text" name="lastName" value={familyName} onChange={this.handleChange} />
                             </label>
                         </p>
 

--- a/src/components/contactACCE.js
+++ b/src/components/contactACCE.js
@@ -217,7 +217,10 @@ class FullContactForm extends React.Component {
                                         </p>
                                     </div>
                                     :
-                                    <div></div>
+                                    <div>
+                                        <input type="hidden" name="contactCell" value={contactCell} />
+                                        <input type="hidden" name="contactTxt" value={contactTxt} />
+                                    </div>
                                 }
                                 {this.state.email ?
                                     <p>
@@ -226,14 +229,16 @@ class FullContactForm extends React.Component {
                                 </label>
                                     </p>
                                     : <div>
-                                        <input type="hidden" name="contactCall" />
-                                        <input type="hidden" name="contactTxt" />
-                                        <input type="hidden" name="contactEmail" />
+                                         <input type="hidden" name="contactEmail" value={contactEmail} />
                                     </div>
                                 }
                             </fieldset>
                             :
-                            <div></div>
+                            <div>
+                                        <input type="hidden" name="contactCall" value={contactCall} />
+                                        <input type="hidden" name="contactTxt" value={contactTxt} />
+                                        <input type="hidden" name="contactEmail" value={contactEmail} />
+                            </div>
                         }
                         <p>
                             <button type="submit">{submitText ? submitText : dict[appCtx.lang].submitText}</button>

--- a/src/components/contactACCE.js
+++ b/src/components/contactACCE.js
@@ -95,7 +95,7 @@ class FullContactForm extends React.Component {
             to: "",
             share1482Answers: true, shareRentCalc: true,
             contactCall: true, contactTxt: true, contactEmail: true,
-            givenName: "", familyName: "", cell: "", email: "",
+            firstName: "", lastName: "", cell: "", email: "",
             rentIncrease: false, eviction: false, landlordOther: false, understandRights: false, fightForRights: false,
             submitText: props.submitText,
             dict: contactDict,
@@ -127,7 +127,7 @@ class FullContactForm extends React.Component {
     };
 
     render() {
-        const { givenName, familyName, cell, email, rentIncrease, eviction, landlordOther, understandRights, fightForRights, share1482Answers, sharecRentCalc, contactEmail, contactTxt, contactCall, submitText, dict } = this.state;
+        const { firstName, lastName, cell, email, rentIncrease, eviction, landlordOther, understandRights, fightForRights, share1482Answers, sharecRentCalc, contactEmail, contactTxt, contactCall, submitText, dict } = this.state;
         return (
             <AppContext.Consumer>
                 {({ appCtx, updateContext }) => (
@@ -135,10 +135,10 @@ class FullContactForm extends React.Component {
                         <input type="hidden" name="form-name" value="testFullContact" />
                         <p>
                             <label>
-                                First: <input type="text" name="firstName" value={givenName} onChange={this.handleChange} />&nbsp;
+                                First: <input type="text" name="firstName" value={firstName} onChange={this.handleChange} />&nbsp;
                     </label>
                             <label>
-                                Last: <input type="text" name="lastName" value={familyName} onChange={this.handleChange} />
+                                Last: <input type="text" name="lastName" value={lastName} onChange={this.handleChange} />
                             </label>
                         </p>
 

--- a/src/components/contactACCE.js
+++ b/src/components/contactACCE.js
@@ -58,10 +58,10 @@ class QuickContactForm extends React.Component {
                                 <input type="hidden" name="form-name" value="testQuickContact" />
                                 <p>
                                     <label>
-                                        First name: <input type="text" name="givenName" value={firstName} onChange={this.handleChange} />&nbsp;
+                                        First name: <input type="text" name="firstName" value={firstName} onChange={this.handleChange} />&nbsp;
                     </label>
                                     <label>
-                                        Last name: <input type="text" name="familyName" value={lastName} onChange={this.handleChange} />
+                                        Last name: <input type="text" name="lastName" value={lastName} onChange={this.handleChange} />
                                     </label>
                                 </p>
                                 <p>
@@ -127,10 +127,10 @@ class FullContactForm extends React.Component {
     };
 
     render() {
-        const { firstName, lastName, cell, email, rentIncrease, eviction, landlordOther, understandRights, fightForRights, share1482Answers, sharecRentCalc, contactEmail, contactTxt, contactCall, submitText, dict } = this.state;
+        const { firstName, lastName, cell, email, rentIncrease, eviction, landlordOther, understandRights, fightForRights, share1482Answers, shareRentCalc, contactEmail, contactTxt, contactCall, submitText, dict } = this.state;
         return (
             <AppContext.Consumer>
-                {({ appCtx, updateContext }) => (
+                {({ appCtx }) => (
                     <form onSubmit={this.handleSubmit} name="testFullContact" data-netlify="true" data-netlify-honeypot="bot-field">
                         <input type="hidden" name="form-name" value="testFullContact" />
                         <p>
@@ -154,23 +154,27 @@ class FullContactForm extends React.Component {
                             <div>
                                 <p>
                                     <label>
-                                        <input type="checkbox" name="rentIncrease" checked={share1482Answers} onChange={this.handleChange} /> Can we share your answers about your housing situation and Tentant Protection Act status with ACCE?
+                                        <input type="checkbox" name="share1482Answers" checked={share1482Answers} onChange={this.handleChange} /> Can we share your answers about your housing situation and Tentant Protection Act status with ACCE?
                                 </label>
                                 </p>
                             </div>
                             :
-                            <div></div>
+                            <div>
+                                <input type="hidden" name="share1482Answers" />
+                            </div>
                         }
                         {(appCtx.rentCalc) ?
                             <div>
                                 <p>
                                     <label>
-                                        <input type="checkbox" name="rentIncrease" checked={sharecRentCalc} onChange={this.handleChange} /> Can we share your rent calculation answers with ACCE?
+                                        <input type="checkbox" name="shareRentCalc" checked={shareRentCalc} onChange={this.handleChange} /> Can we share your rent calculation answers with ACCE?
                                 </label>
                                 </p>
                             </div>
                             :
-                            <div></div>
+                            <div>
+                                <input type="hidden" name="shareRentCalc" />
+                            </div>
                         }
                         <fieldset>
                             <legend>What do you want to connect with ACCE about?</legend>

--- a/src/components/contactACCE.js
+++ b/src/components/contactACCE.js
@@ -54,7 +54,7 @@ class QuickContactForm extends React.Component {
                 {({ appCtx, updateContext }) => (
                     !appCtx.quickFormSubmit ?
                         <div>
-                            <form onSubmit={(e) => { this.handleSubmit(e, updateContext) }} name="testContact" data-netlify="true" data-netlify-honeypot="bot-field">
+                            <form onSubmit={(e) => { this.handleSubmit(e, updateContext) }} name="testQuickContact" data-netlify="true" data-netlify-honeypot="bot-field">
                                 <input type="hidden" name="form-name" value="testQuickContact" />
                                 <p>
                                     <label>
@@ -131,7 +131,7 @@ class FullContactForm extends React.Component {
         return (
             <AppContext.Consumer>
                 {({ appCtx, updateContext }) => (
-                    <form onSubmit={this.handleSubmit} name="testContact" data-netlify="true" data-netlify-honeypot="bot-field">
+                    <form onSubmit={this.handleSubmit} name="testFullContact" data-netlify="true" data-netlify-honeypot="bot-field">
                         <input type="hidden" name="form-name" value="testFullContact" />
                         <p>
                             <label>

--- a/src/components/contactACCE.js
+++ b/src/components/contactACCE.js
@@ -225,7 +225,11 @@ class FullContactForm extends React.Component {
                                             <input type="checkbox" name="contactEmail" checked={contactEmail} onChange={this.handleChange} /> Contact me by email
                                 </label>
                                     </p>
-                                    : <div></div>
+                                    : <div>
+                                        <input type="hidden" name="contactCall" />
+                                        <input type="hidden" name="contactTxt" />
+                                        <input type="hidden" name="contactEmail" />
+                                    </div>
                                 }
                             </fieldset>
                             :

--- a/src/components/contactACCE.js
+++ b/src/components/contactACCE.js
@@ -32,7 +32,7 @@ class QuickContactForm extends React.Component {
         fetch("/", {
             method: "POST",
             headers: { "Content-Type": "application/x-www-form-urlencoded" },
-            body: encode({ "form-name": "testContact", ...this.state })
+            body: encode({ "form-name": "testQuickContact", ...this.state })
         })
             .then(() => {
                 const quickFormSubmit = true;
@@ -108,7 +108,7 @@ class FullContactForm extends React.Component {
         fetch("/", {
             method: "POST",
             headers: { "Content-Type": "application/x-www-form-urlencoded" },
-            body: encode({ "form-name": "testContact", ...this.state })
+            body: encode({ "form-name": "testFullContact", ...this.state })
         })
             .then(() => alert("Success!"))
             .catch(error => alert(error));

--- a/src/components/contactACCE.js
+++ b/src/components/contactACCE.js
@@ -1,16 +1,105 @@
 import React from "react";
+import AppContext from "./AppContext"
 
 const encode = (data) => {
     return Object.keys(data)
         .map(key => encodeURIComponent(key) + "=" + encodeURIComponent(data[key]))
         .join("&");
-}
+};
+
+var contactDict = {
+    en: { submitText: "Connect with ACCE" },
+    es: { submitText: "Contactar ACCE" }
+};
 
 
-class ContactForm extends React.Component {
+class QuickContactForm extends React.Component {
     constructor(props) {
         super(props);
-        this.state = { name: "", email: "", message: "" };
+        this.state = {
+            givenName: "",
+            familyName: "",
+            cell: "",
+            email: "",
+            submitText: props.submitText,
+            dict: contactDict,
+        };
+    }
+
+    /* Here’s the juicy bit for posting the form submission */
+
+    handleSubmit = (e, updateContext) => {
+        fetch("/", {
+            method: "POST",
+            headers: { "Content-Type": "application/x-www-form-urlencoded" },
+            body: encode({ "form-name": "testContact", ...this.state })
+        })
+            .then(() => {
+                const quickFormSubmit = true;
+                updateContext({ quickFormSubmit });
+            })
+            .catch(error => alert(error));
+
+        e.preventDefault();
+
+
+    };
+
+    handleChange = e => this.setState({ [e.target.name]: e.target.value });
+
+    render() {
+        const { givenName, familyName, cell, email, submitText, dict } = this.state;
+        return (
+            <AppContext.Consumer>
+                {({ appCtx, updateContext }) => (
+                    !appCtx.quickFormSubmit ?
+                        <div>
+                            <form onSubmit={(e) => { this.handleSubmit(e, updateContext) }} name="testContact" data-netlify="true" data-netlify-honeypot="bot-field">
+                                <input type="hidden" name="form-name" value="testContact" />
+                                <p>
+                                    <label>
+                                        Given name: <input type="text" name="givenName" value={givenName} onChange={this.handleChange} />&nbsp;
+                    </label>
+                                    <label>
+                                        Family name: <input type="text" name="familyName" value={familyName} onChange={this.handleChange} />
+                                    </label>
+                                </p>
+                                <p>
+                                    <label>
+                                        Cell: <input type="tel" name="cell" value={cell} onChange={this.handleChange} />
+                                    </label>
+                                    <label>
+                                        Email: <input type="email" name="email" value={email} onChange={this.handleChange} />
+                                    </label>
+                                </p>
+                                <p>
+                                    <button type="submit">{submitText ? submitText : dict[appCtx.lang].submitText}</button>
+                                </p>
+                            </form>
+                        </div>
+                        :
+                        <div />
+                )}
+            </AppContext.Consumer>
+        );
+    }
+}
+
+class FullContactForm extends React.Component {
+    constructor(props) {
+        super(props);
+        if (props.to === undefined || props.to === null || props.to === "") {
+            this.setState({ hasError: true });
+        }
+        this.state = {
+            to: "",
+            share1482Answers: true, shareRentCalc: true,
+            contactCall: true, contactTxt: true, contactEmail: true,
+            givenName: "", familyName: "", cell: "", email: "",
+            rentIncrease: false, eviction: false, landlordOther: false, understandRights: false, fightForRights: false,
+            submitText: props.submitText,
+            dict: contactDict,
+        };
     }
 
     /* Here’s the juicy bit for posting the form submission */
@@ -27,34 +116,130 @@ class ContactForm extends React.Component {
         e.preventDefault();
     };
 
-    handleChange = e => this.setState({ [e.target.name]: e.target.value });
+    checkBoxes = { "rentIncrease": true, "eviction": true, "landlordOther": true, "understandRights": true, "fightForRights": true };
+
+    handleChange = e => {
+        var value = e.target.value;
+        if (this.checkBoxes[e.target.name]) {
+            value = !this.state[e.target.name];
+        }
+        this.setState({ [e.target.name]: value })
+    };
 
     render() {
-        const { name, email, message } = this.state;
+        const { givenName, familyName, cell, email, rentIncrease, eviction, landlordOther, understandRights, fightForRights, share1482Answers, sharecRentCalc, contactEmail, contactTxt, contactCall, submitText, dict } = this.state;
         return (
-            <form onSubmit={this.handleSubmit} name="testContact" data-netlify="true" data-netlify-honeypot="bot-field">
-                 <input type="hidden" name="form-name" value="testContact"/>
-                <p>
-                    <label>
-                        Your Name: <input type="text" name="name" value={name} onChange={this.handleChange} />
+            <AppContext.Consumer>
+                {({ appCtx, updateContext }) => (
+                    <form onSubmit={this.handleSubmit} name="testContact" data-netlify="true" data-netlify-honeypot="bot-field">
+                        <input type="hidden" name="form-name" value="testContact" />
+                        <p>
+                            <label>
+                                Given name: <input type="text" name="givenName" value={givenName} onChange={this.handleChange} />&nbsp;
                     </label>
-                </p>
-                <p>
-                    <label>
-                        Your Email: <input type="email" name="email" value={email} onChange={this.handleChange} />
-                    </label>
-                </p>
-                <p>
-                    <label>
-                        Message: <textarea name="message" value={message} onChange={this.handleChange} />
-                    </label>
-                </p>
-                <p>
-                    <button type="submit">Send</button>
-                </p>
-            </form>
+                            <label>
+                                Family name: <input type="text" name="familyName" value={familyName} onChange={this.handleChange} />
+                            </label>
+                        </p>
+
+                        <p>
+                            <label>
+                                Cell: <input type="tel" name="cell" value={cell} onChange={this.handleChange} />
+                            </label>
+                            <label>
+                                Email: <input type="email" name="email" value={email} onChange={this.handleChange} />
+                            </label>
+                        </p>
+                        {(appCtx.eligibiltyAnswers) ?
+                            <div>
+                                <p>
+                                    <label>
+                                        <input type="checkbox" name="rentIncrease" checked={share1482Answers} onChange={this.handleChange} /> Can we share your answers about your housing situation and Tentant Protection Act status with ACCE?
+                                </label>
+                                </p>
+                            </div>
+                            :
+                            <div></div>
+                        }
+                        {(appCtx.rentCalc) ?
+                            <div>
+                                <p>
+                                    <label>
+                                        <input type="checkbox" name="rentIncrease" checked={sharecRentCalc} onChange={this.handleChange} /> Can we share your rent calculation answers with ACCE?
+                                </label>
+                                </p>
+                            </div>
+                            :
+                            <div></div>
+                        }
+                        <fieldset>
+                            <legend>What do you want to connect with ACCE about?</legend>
+                            <p>
+                                <label>
+                                    <input type="checkbox" name="rentIncrease" checked={rentIncrease} onChange={this.handleChange} /> My landlord wants to (or did) raise my rent
+                                </label>
+                            </p>
+                            <p>
+                                <label>
+                                    <input type="checkbox" name="eviction" checked={eviction} onChange={this.handleChange} /> My landlord told me I'm going to be evicted
+                                </label>
+                            </p>
+                            <p>
+                                <label>
+                                    <input type="checkbox" name="landlordOther" checked={landlordOther} onChange={this.handleChange} /> Another issue with my landlord
+                                </label>
+                            </p>
+                            <p>
+                                <label>
+                                    <input type="checkbox" name="understandRights" checked={understandRights} onChange={this.handleChange} /> I want to better understand my rights as a tenant
+                                </label>
+                            </p>
+                            <p>
+                                <label>
+                                    <input type="checkbox" name="fightForRights" checked={fightForRights} onChange={this.handleChange} /> I want to help fight for tenant rights
+                                </label>
+                            </p>
+                        </fieldset>
+                        {(this.state.email || this.state.cell) ?
+                            <fieldset>
+                                <legend>How would you prefer to be contacted?</legend>
+                                {this.state.cell ?
+                                    <div>
+                                        <p>
+                                            <label>
+                                                <input type="checkbox" name="contactCall" checked={contactCall} onChange={this.handleChange} /> Contact me by phone
+                                </label>
+                                        </p>
+                                        <p>
+                                            <label>
+                                                <input type="checkbox" name="contactTxt" checked={contactTxt} onChange={this.handleChange} /> Contact me by SMS (text)
+                                </label>
+                                        </p>
+                                    </div>
+                                    :
+                                    <div></div>
+                                }
+                                {this.state.email ?
+                                    <p>
+                                        <label>
+                                            <input type="checkbox" name="contactEmail" checked={contactEmail} onChange={this.handleChange} /> Contact me by email
+                                </label>
+                                    </p>
+                                    : <div></div>
+                                }
+                            </fieldset>
+                            :
+                            <div></div>
+                        }
+                        <p>
+                            <button type="submit">{submitText ? submitText : dict[appCtx.lang].submitText}</button>
+                        </p>
+                    </form>
+                )}
+            </AppContext.Consumer>
         );
     }
 }
 
-export default ContactForm;
+export default QuickContactForm;
+export { QuickContactForm, FullContactForm };

--- a/src/components/contactACCE.js
+++ b/src/components/contactACCE.js
@@ -17,8 +17,8 @@ class QuickContactForm extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            givenName: "",
-            familyName: "",
+            firstName: "",
+            lastName: "",
             cell: "",
             email: "",
             submitText: props.submitText,
@@ -48,7 +48,7 @@ class QuickContactForm extends React.Component {
     handleChange = e => this.setState({ [e.target.name]: e.target.value });
 
     render() {
-        const { givenName, familyName, cell, email, submitText, dict } = this.state;
+        const { firstName, lastName, cell, email, submitText, dict } = this.state;
         return (
             <AppContext.Consumer>
                 {({ appCtx, updateContext }) => (
@@ -58,10 +58,10 @@ class QuickContactForm extends React.Component {
                                 <input type="hidden" name="form-name" value="testQuickContact" />
                                 <p>
                                     <label>
-                                        Given name: <input type="text" name="givenName" value={givenName} onChange={this.handleChange} />&nbsp;
+                                        First name: <input type="text" name="givenName" value={firstName} onChange={this.handleChange} />&nbsp;
                     </label>
                                     <label>
-                                        Family name: <input type="text" name="familyName" value={familyName} onChange={this.handleChange} />
+                                        Last name: <input type="text" name="familyName" value={lastName} onChange={this.handleChange} />
                                     </label>
                                 </p>
                                 <p>

--- a/src/components/contactACCE.js
+++ b/src/components/contactACCE.js
@@ -116,7 +116,7 @@ class FullContactForm extends React.Component {
         e.preventDefault();
     };
 
-    checkBoxes = { "rentIncrease": true, "eviction": true, "landlordOther": true, "understandRights": true, "fightForRights": true };
+    checkBoxes = { "rentIncrease": true, "eviction": true, "landlordOther": true, "understandRights": true, "fightForRights": true , contactCall: true, contactEmail: true, contactTxt: true};
 
     handleChange = e => {
         var value = e.target.value;

--- a/src/pages/calculator.js
+++ b/src/pages/calculator.js
@@ -18,6 +18,9 @@ import zipDB from '../../data/zipDB.js'
 import calendar from '../images/calendar.svg'
 import 'bootstrap/dist/css/bootstrap.css';
 
+import { QuickContactForm } from '../components/Contact';
+import AppContext from '../components/AppContext';
+
 const emptyRentRange1 = {
   rent: 0,
   startDate: moment([2019, 2, 15]),
@@ -150,7 +153,7 @@ class Calculator extends React.Component {
     const rentRangeList = rentRanges.map((rent, idx) => (
       <li className="rent-input-row" key={rent.id}>
         {idx > 1
-            && <DangerButton className="remove" onClick={() => that.removeRentRange(idx)}>&times;</DangerButton>}
+          && <DangerButton className="remove" onClick={() => that.removeRentRange(idx)}>&times;</DangerButton>}
         {idx === 0
           ? (
             <div className="input-group mb-3">
@@ -218,21 +221,23 @@ class Calculator extends React.Component {
       )
     })
     return (
-      <div className="calculator-container">
-        {/* <SEO title="Calculator" /> */}
-        <div className="calculator-description">
-          <h1>Rent Calculator</h1>
-          <p>
-            Renters eligible for protection under the Tenant Protection Act are protected against
-            rent increases that exceed 10% in a one year period or the cost of living + 5%,
-            whichever is lower. If you have received a rent increase you can use our calculator
-            to help you determine what the allowable increase is under the law, and if your rent
-            increase exceeds the limit.
-            Eligible renters who got a rent increase anytime on or after March 15, 2019
-            should use the rent calculator, as increases in 2019 may be rolled back
-            resulting in a rent reduction.
+      <AppContext.Consumer>
+        {({ appCtx }) => (
+          <div className="calculator-container">
+            {/* <SEO title="Calculator" /> */}
+            <div className="calculator-description">
+              <h1>Rent Calculator</h1>
+              <p>
+                Renters eligible for protection under the Tenant Protection Act are protected against
+                rent increases that exceed 10% in a one year period or the cost of living + 5%,
+                whichever is lower. If you have received a rent increase you can use our calculator
+                to help you determine what the allowable increase is under the law, and if your rent
+                increase exceeds the limit.
+                Eligible renters who got a rent increase anytime on or after March 15, 2019
+                should use the rent calculator, as increases in 2019 may be rolled back
+                resulting in a rent reduction.
           </p>
-          {/* {this.state.hideMailChimp
+              {/* {this.state.hideMailChimp
             ? (
               <PrimaryButton onClick={() => this.setState({ hideMailChimp: false })}>
                 I am interested in signing up to learn more
@@ -240,60 +245,71 @@ class Calculator extends React.Component {
             ) : (
               <MailChimp />
             )} */}
-        <iframe className="google-form" src="https://docs.google.com/forms/d/e/1FAIpQLScXhoVcWIEwDiToU4kcA_Mz-O5QgcTUeyBla7Op3lf3k_GZ8w/viewform?embedded=true" height="250" frameborder="0" marginheight="0" marginwidth="0">Loading…</iframe>
-        </div>
-        <div className="card">
-          <div className="card-body">
-            <h5 className="card-title">What is your zip code?</h5>
-            <input className="form-control" type="text" onChange={(e) => this.setCpiFromZip(e)} placeholder="Your 5 digit zip code" />
-            {this.state.town
-              && (
-              <small><strong>{this.state.town}</strong>{this.state.county
-                && <strong>, {this.state.county} County</strong>}
-              </small>
-              )}
-            <br />
-            <br />
-            <br />
-            <h5>What was your rent on or since March 15, 2019?</h5>
-            <div className="input-group mb-3">
-              <div className="input-group-prepend">
-                <span className="input-group-text">$</span>
-              </div>
-              <input
-                type="number"
-                className="form-control"
-                value={this.state.pastRent}
-                placeholder="Monthly Rent"
-                onChange={(e) => this.handlePastRentChange(e)}
-              />
+              {!appCtx.quickFormSubmit ?
+                <div className="card">
+
+                  <div className="card-body">
+                    <h5>Psst... before you calculate your rent</h5>
+                    <p>If you share your contact details with us we can follow up later to support you with your housing situation</p>
+                    <QuickContactForm autohide={true} />
+                  </div>
+                </div>
+                :
+                <div />
+              }
             </div>
-          </div>
-        </div>
-        <br />
-        <br />
-        <ul className="calculator-results">
-          <li>
-            <h5 className="result-title">Max Increase</h5>
-            {this.state.cpiSelection
-              ? <h3>{parseFloat((0.05 + parseFloat(this.state.cpi)) * 100).toFixed(2)}%</h3>
-              : <h3>-</h3>}
-            <small>5% Base + {parseFloat(this.state.cpi * 100).toFixed(2)}% CPI</small>
+            <div className="card">
+              <div className="card-body">
+                <h5 className="card-title">What is your zip code?</h5>
+                <input className="form-control" type="text" onChange={(e) => this.setCpiFromZip(e)} placeholder="Your 5 digit zip code" />
+                {this.state.town
+                  && (
+                    <small><strong>{this.state.town}</strong>{this.state.county
+                      && <strong>, {this.state.county} County</strong>}
+                    </small>
+                  )}
+                <br />
+                <br />
+                <br />
+                <h5>What was your rent on or since March 15, 2019?</h5>
+                <div className="input-group mb-3">
+                  <div className="input-group-prepend">
+                    <span className="input-group-text">$</span>
+                  </div>
+                  <input
+                    type="number"
+                    className="form-control"
+                    value={this.state.pastRent}
+                    placeholder="Monthly Rent"
+                    onChange={(e) => this.handlePastRentChange(e)}
+                  />
+                </div>
+              </div>
+            </div>
             <br />
-            <small><strong>{this.state.cpiSelection ? this.state.cpiSelection : ''}</strong></small>
-          </li>
-          <li>
-            <h5 className="result-title">Allowable Rent</h5>
-            {(maxRent > 0 && this.state.cpiSelection)
-              ? <h3>${maxRent}</h3>
-              : <h3>-</h3>}
-            <small>Beginning Jan 1, 2020</small>
-          </li>
-        </ul>
-        <Disclaimer />
-        <br />
-        <br />
-        {/* {this.state.showSection
+            <br />
+            <ul className="calculator-results">
+              <li>
+                <h5 className="result-title">Max Increase</h5>
+                {this.state.cpiSelection
+                  ? <h3>{parseFloat((0.05 + parseFloat(this.state.cpi)) * 100).toFixed(2)}%</h3>
+                  : <h3>-</h3>}
+                <small>5% Base + {parseFloat(this.state.cpi * 100).toFixed(2)}% CPI</small>
+                <br />
+                <small><strong>{this.state.cpiSelection ? this.state.cpiSelection : ''}</strong></small>
+              </li>
+              <li>
+                <h5 className="result-title">Allowable Rent</h5>
+                {(maxRent > 0 && this.state.cpiSelection)
+                  ? <h3>${maxRent}</h3>
+                  : <h3>-</h3>}
+                <small>Beginning Jan 1, 2020</small>
+              </li>
+            </ul>
+            <Disclaimer />
+            <br />
+            <br />
+            {/* {this.state.showSection
           ? (
             <h4>
               Enter your information below to determine how much money
@@ -304,40 +320,42 @@ class Calculator extends React.Component {
               Did your rent increase on or after January 1st, 2020?
             </PrimaryButton2>
           )} */}
-        <br />
-        {this.state.showSection
-          && (
-          <section>
-            <div className="card">
-              <div className="card-body">
-                <h5 className="card-title">Enter your rent history from January 1st, 2020 to now.</h5>
-                <section className="rent-increases">
-                  <ul>{rentRangeList}</ul>
-                  <SuccessButton className="add" onClick={this.addRentRange}>+</SuccessButton>
-                </section>
-              </div>
-            </div>
             <br />
-            <h4 className="refund-information">
-Based on the information provided, you may be owed
+            {this.state.showSection
+              && (
+                <section>
+                  <div className="card">
+                    <div className="card-body">
+                      <h5 className="card-title">Enter your rent history from January 1st, 2020 to now.</h5>
+                      <section className="rent-increases">
+                        <ul>{rentRangeList}</ul>
+                        <SuccessButton className="add" onClick={this.addRentRange}>+</SuccessButton>
+                      </section>
+                    </div>
+                  </div>
+                  <br />
+                  <h4 className="refund-information">
+                    Based on the information provided, you may be owed
             </h4>
-            <div className="refund-container">
-              <h1>${refund}</h1>
-              { refund > 0
-                && (
-                  <ul>
-                    {refundBreakdown}
-                  </ul>
-                )}
-            </div>
-            <br />
-            {/* <PrimaryButton onClick={() => this.setState({showLetter: true})}>
+                  <div className="refund-container">
+                    <h1>${refund}</h1>
+                    {refund > 0
+                      && (
+                        <ul>
+                          {refundBreakdown}
+                        </ul>
+                      )}
+                  </div>
+                  <br />
+                  {/* <PrimaryButton onClick={() => this.setState({showLetter: true})}>
             Generate a letter to your landlord</PrimaryButton> */}
-          </section>
-          )}
-        {/* {this.state.showLetter
+                </section>
+              )}
+            {/* {this.state.showLetter
           && <GenerateLetter />} */}
-      </div>
+          </div>
+        )}
+      </AppContext.Consumer>
     );
   }
 }

--- a/src/pages/calculator.js
+++ b/src/pages/calculator.js
@@ -20,6 +20,7 @@ import 'bootstrap/dist/css/bootstrap.css';
 
 import { QuickContactForm } from '../components/Contact';
 import AppContext from '../components/AppContext';
+import AutoSubmit from '../components/AutoSubmit';
 
 const emptyRentRange1 = {
   rent: 0,
@@ -258,6 +259,7 @@ class Calculator extends React.Component {
                 <div />
               }
             </div>
+            <AutoSubmit />
             <div className="card">
               <div className="card-body">
                 <h5 className="card-title">What is your zip code?</h5>

--- a/src/pages/calculator.js
+++ b/src/pages/calculator.js
@@ -316,7 +316,7 @@ class Calculator extends React.Component {
               </li>
             </ul>
             { maxRent ?
-            <AutoSubmit />
+            <AutoSubmit pageName="calculatorAutoSubmit" />
             :
             <div />
             }

--- a/src/pages/calculator.js
+++ b/src/pages/calculator.js
@@ -122,7 +122,7 @@ class Calculator extends React.Component {
   handlePastRentChange(e, updateContext) {
     this.setState({ pastRent: e.target.value });
     this.handleRentRangeValueChange(e, 0, updateContext);
-    updateContext({ pastRent: e.target.value })
+    updateContext({ pastRent: e.target.valueg })
   }
 
   removeRentRange(idx) {

--- a/src/pages/calculator.js
+++ b/src/pages/calculator.js
@@ -107,20 +107,22 @@ class Calculator extends React.Component {
     this.setState(() => ({ rentRanges: t }));
   }
 
-  handleRentRangeValueChange(e, idx) {
+  handleRentRangeValueChange(e, idx, updateContext) {
     const t = this.state.rentRanges.slice(0);
     t[idx].rent = e.target.value;
     if (idx === 0) {
       this.setState({ pastRent: t[idx].rent });
     }
     this.setState({ rentRanges: t });
-    const temp = calculateTotalAmountOwedToTenant(t, this.state.cpi);
+    const temp = calculateTotalAmountOwedToTenant(t, this.state.cpi, updateContext);
+    updateContext({ rentIncrease: temp });
     this.props.changeRefund(temp);
   }
 
-  handlePastRentChange(e) {
+  handlePastRentChange(e, updateContext) {
     this.setState({ pastRent: e.target.value });
-    this.handleRentRangeValueChange(e, 0);
+    this.handleRentRangeValueChange(e, 0, updateContext);
+    updateContext({ pastRent: e.target.value })
   }
 
   removeRentRange(idx) {

--- a/src/pages/calculator.js
+++ b/src/pages/calculator.js
@@ -270,7 +270,7 @@ class Calculator extends React.Component {
             <div className="card">
               <div className="card-body">
                 <h5 className="card-title">What is your zip code?</h5>
-                <input className="form-control" type="text" onChange={(e) => this.setCpiFromZip(e, updateContext)} placeholder="Your 5 digit zip code" value={this.state.zip} />
+                <input className="form-control" type="text" onChange={(e) => this.setCpiFromZip(e, updateContext)} placeholder="Your 5 digit zip code" />
                 {this.state.town
                   && (
                     <small><strong>{this.state.town}</strong>{this.state.county

--- a/src/pages/calculator.js
+++ b/src/pages/calculator.js
@@ -65,6 +65,7 @@ class Calculator extends React.Component {
       // cpiSelection: INITIAL_SELECTION,
       cpiSelection: undefined,
       rentRanges: [emptyRentRange1, emptyRentRange2],
+      zip: ""
     };
     this.handleInput = handleInput.bind(this);
     this.handlePastRentChange = this.handlePastRentChange.bind(this);
@@ -77,18 +78,23 @@ class Calculator extends React.Component {
     this.addRentRange = this.addRentRange.bind(this);
   }
 
-  setCpiFromZip(e) {
+  setCpiFromZip(e, updateContext) {
     const input = e.target.value
-    const zip = zipDB[input]
+    const zip = zipDB[input];
+    const validCAZip = zip ? true : false;
+    var cpi, town, county, cpiSelection, area;
+
     if (zip) {
-      const cpi = areaToCpi[zip.area];
-      const town = zip.town;
-      const county = zip.county;
-      const cpiSelection = zip.area;
+      cpi = areaToCpi[zip.area];
+      town = zip.town;
+      county = zip.county;
+      area = zip.area;
+      cpiSelection = zip.area;
       this.setState({
-        cpi, cpiSelection, town, county,
+        cpi, cpiSelection, town, county, zip: input
       })
     }
+    updateContext({ zip: input,  validCAZip, county, town, area, cpiSelection });
   }
 
   handleRentRangeDateChange(e, idx) {
@@ -223,7 +229,7 @@ class Calculator extends React.Component {
     })
     return (
       <AppContext.Consumer>
-        {({ appCtx }) => (
+        {({ appCtx, updateContext }) => (
           <div className="calculator-container">
             {/* <SEO title="Calculator" /> */}
             <div className="calculator-description">
@@ -259,11 +265,10 @@ class Calculator extends React.Component {
                 <div />
               }
             </div>
-            <AutoSubmit />
             <div className="card">
               <div className="card-body">
                 <h5 className="card-title">What is your zip code?</h5>
-                <input className="form-control" type="text" onChange={(e) => this.setCpiFromZip(e)} placeholder="Your 5 digit zip code" />
+                <input className="form-control" type="text" onChange={(e) => this.setCpiFromZip(e, updateContext)} placeholder="Your 5 digit zip code" value={this.state.zip} />
                 {this.state.town
                   && (
                     <small><strong>{this.state.town}</strong>{this.state.county
@@ -283,7 +288,7 @@ class Calculator extends React.Component {
                     className="form-control"
                     value={this.state.pastRent}
                     placeholder="Monthly Rent"
-                    onChange={(e) => this.handlePastRentChange(e)}
+                    onChange={(e) => this.handlePastRentChange(e, updateContext)}
                   />
                 </div>
               </div>
@@ -308,6 +313,11 @@ class Calculator extends React.Component {
                 <small>Beginning Jan 1, 2020</small>
               </li>
             </ul>
+            { maxRent ?
+            <AutoSubmit />
+            :
+            <div />
+            }
             <Disclaimer />
             <br />
             <br />

--- a/src/pages/eligibility/state/coverage/covered.mdx
+++ b/src/pages/eligibility/state/coverage/covered.mdx
@@ -1,5 +1,6 @@
 import { PrimaryButton } from "../../../../components/Buttons";
 import AppContext from "../../../../components/AppContext"
+import AutoSubmit from "../../../../components/AutoSubmit"
 
 # Your Rights
 
@@ -8,6 +9,9 @@ import AppContext from "../../../../components/AppContext"
 <AppContext.Consumer>
     {({ appCtx }) => (
         <div>
+            { 
+                <AutoSubmit />
+            }
             <h2>Protection from "unjust" evictions</h2>
             {(appCtx.ab1482TenancyDuration && appCtx.builtBefore2005==='yes') ? 
                 <p><strong>Congratulations</strong> you are protected from "unjust" evictions under AB-1482.</p>

--- a/src/pages/eligibility/state/coverage/covered.mdx
+++ b/src/pages/eligibility/state/coverage/covered.mdx
@@ -38,7 +38,7 @@ import AutoSubmit from "../../../../components/AutoSubmit"
             }
             <p>Remember these aren't your only rights as a tenant, just the ones covered by AB-1482. If you are in doubt, or worried about your living situation reach out to your local city or county government for support, or a local tenants rights group. We can connect you with them below.</p>
             <h1>Having issues with your tenancy?</h1>
-            <PrimaryButton to="/gethelp">Get help now!</PrimaryButton>
+            <PrimaryButton to="/getHelp">Get help now!</PrimaryButton>
         </div>
     )}
 </AppContext.Consumer>

--- a/src/pages/eligibility/state/coverage/notCovered.mdx
+++ b/src/pages/eligibility/state/coverage/notCovered.mdx
@@ -28,4 +28,4 @@ import { PrimaryButton } from "../../../../components/Buttons";
 </AppContext.Consumer>
 
 ## Are you having issues with your landlord?
-<PrimaryButton to="/gethelp">Get help now!</PrimaryButton>
+<PrimaryButton to="/getHelp">Get help now!</PrimaryButton>

--- a/src/pages/es/calculator.js
+++ b/src/pages/es/calculator.js
@@ -26,6 +26,10 @@ import zipDB from "../../../data/zipDB.js";
 import calendar from "../../images/calendar.svg";
 import "bootstrap/dist/css/bootstrap.css";
 
+
+import { QuickContactForm } from '../../components/Contact';
+import AppContext from '../../components/AppContext';
+
 const emptyRentRange1 = {
   rent: 0,
   startDate: moment([2019, 2, 15]),
@@ -137,7 +141,7 @@ class Calculator extends React.Component {
   calculateRentIncreasePercentage() {
     return parseFloat(
       ((this.state.currentRent - this.state.pastRent) / this.state.pastRent) *
-        100
+      100
     ).toFixed(0);
   }
 
@@ -194,48 +198,48 @@ class Calculator extends React.Component {
             </div>
           </div>
         ) : (
-          <div className="rent-input">
-            <div className="input-group mb-3">
-              <div className="input-group-prepend">
-                <span className="input-group-text">$</span>
+            <div className="rent-input">
+              <div className="input-group mb-3">
+                <div className="input-group-prepend">
+                  <span className="input-group-text">$</span>
+                </div>
+                <input
+                  type="number"
+                  className="form-control"
+                  placeholder="Monthly Rent"
+                  onChange={e => this.handleRentRangeValueChange(e, idx)}
+                />
               </div>
-              <input
-                type="number"
-                className="form-control"
-                placeholder="Monthly Rent"
-                onChange={e => this.handleRentRangeValueChange(e, idx)}
-              />
-            </div>
-            <div className="rent-date">
-              <div className="rent-date-label">
-                <small>From</small>
-                <small>To</small>
-              </div>
-              <div className="rent-date-picker">
-                <div className="input-group mb-3">
-                  <div className="input-group-prepend date-icon">
-                    <img
-                      className="input-group-text"
-                      src={calendar}
-                      alt="calendar"
+              <div className="rent-date">
+                <div className="rent-date-label">
+                  <small>From</small>
+                  <small>To</small>
+                </div>
+                <div className="rent-date-picker">
+                  <div className="input-group mb-3">
+                    <div className="input-group-prepend date-icon">
+                      <img
+                        className="input-group-text"
+                        src={calendar}
+                        alt="calendar"
+                      />
+                    </div>
+                    <DateRangePicker
+                      endDate={rentRanges[idx].endDate}
+                      endDateId="endDate"
+                      focusedInput={rentRanges[idx].focusedInput}
+                      isOutsideRange={() => null}
+                      onDatesChange={e => this.handleRentRangeDateChange(e, idx)}
+                      onFocusChange={e => this.handleFocusChange(e, idx)}
+                      startDate={rentRanges[idx].startDate}
+                      startDateId="startDate"
+                      orientation="vertical"
                     />
                   </div>
-                  <DateRangePicker
-                    endDate={rentRanges[idx].endDate}
-                    endDateId="endDate"
-                    focusedInput={rentRanges[idx].focusedInput}
-                    isOutsideRange={() => null}
-                    onDatesChange={e => this.handleRentRangeDateChange(e, idx)}
-                    onFocusChange={e => this.handleFocusChange(e, idx)}
-                    startDate={rentRanges[idx].startDate}
-                    startDateId="startDate"
-                    orientation="vertical"
-                  />
                 </div>
               </div>
             </div>
-          </div>
-        )}
+          )}
       </li>
     ));
     const refundBreakdown = rentRanges.map((range, idx) => {
@@ -263,115 +267,112 @@ class Calculator extends React.Component {
       );
     });
     return (
-      <div>
-        {/* <SEO title="Calculator" /> */}
-        <div className="calculator-description">
-          <h1>Calculadora de Renta</h1>
-          <p>
-            Los inquilinos elegibles para protección bajo la Ley de Protección
-            al Inquilino de 2019 están protegidos contra aumentos de renta
-            que exceden el 10% en un período de un año o la inflación + 5%, lo
-            que sea menor. Si ha recibido un aumento de renta, puede usar
-            nuestra calculadora para ayudarlo a determinar cuál es el aumento
-            permitido según la ley, y si su aumento de renta excede el límite.
-            Los inquilinos elegibles que obtuvieron un aumento en la renta en
-            cualquier momento a partir del 15 de marzo de 2019 deben usar la
-            calculadora de renta, ya que los aumentos en 2019 pueden
-            revertirse, lo que resulta en una reducción de la renta.
+      <AppContext.Consumer>
+        {({ appCtx }) => (
+          <div className="calculator-container">
+            {/* <SEO title="Calculator" /> */}
+            <div className="calculator-description">
+              <h1>Calculadora de Renta</h1>
+              <p>
+                Los inquilinos elegibles para protección bajo la Ley de Protección
+                al Inquilino de 2019 están protegidos contra aumentos de renta
+                que exceden el 10% en un período de un año o la inflación + 5%, lo
+                que sea menor. Si ha recibido un aumento de renta, puede usar
+                nuestra calculadora para ayudarlo a determinar cuál es el aumento
+                permitido según la ley, y si su aumento de renta excede el límite.
+                Los inquilinos elegibles que obtuvieron un aumento en la renta en
+                cualquier momento a partir del 15 de marzo de 2019 deben usar la
+                calculadora de renta, ya que los aumentos en 2019 pueden
+                revertirse, lo que resulta en una reducción de la renta.
           </p>
-          {/* {this.state.hideMailChimp
-            ? (
-              <PrimaryButton onClick={() => this.setState({ hideMailChimp: false })}>
-                I am interested in signing up to learn more
-              </PrimaryButton>
-            ) : (
-              <MailChimp />
-            )} */}
-          <iframe
-            src="https://docs.google.com/forms/d/e/1FAIpQLScXhoVcWIEwDiToU4kcA_Mz-O5QgcTUeyBla7Op3lf3k_GZ8w/viewform?embedded=true"
-            width="640"
-            height="250"
-            frameborder="0"
-            marginheight="0"
-            marginwidth="0"
-          >
-            Loading…
-          </iframe>
-        </div>
-        <div className="card">
-          <div className="card-body">
-            <h5 className="card-title">Cual es su Codigo Postal?</h5>
-            <input
-              className="form-control"
-              type="text"
-              onChange={e => this.setCpiFromZip(e)}
-              placeholder="Los 5 digitos de su codigo postal (zip code)"
-            />
-            {this.state.town && (
-              <small>
-                <strong>{this.state.town}</strong>
-                {this.state.county && (
-                  <strong>, Condado de {this.state.county}</strong>
-                )}
-              </small>
-            )}
-            <br />
-            <br />
-            <br />
-            <h5>Cuanto estaba pagando de renta en o desde Marzo 15, 2019?</h5>
-            <div className="input-group mb-3">
-              <div className="input-group-prepend">
-                <span className="input-group-text">$</span>
-              </div>
-              <input
-                type="number"
-                className="form-control"
-                value={this.state.pastRent}
-                placeholder="Monto de renta"
-                onChange={e => this.handlePastRentChange(e)}
-              />
+              {!appCtx.quickFormSubmit ?
+                <div className="card">
+
+                  <div className="card-body">
+                    <h5>¡Pst ... antes de calcular su renta</h5>
+                    <p>Si comparte sus datos de contacto con nosotros, podemos hacer un seguimiento posterior para ayudarlo con su situación de vivienda</p>
+                    <QuickContactForm autohide={true} />
+                  </div>
+                </div>
+                :
+                <div />
+              }
+
             </div>
-          </div>
-        </div>
-        <br />
-        <br />
-        <ul className="calculator-results">
-          <li>
-            <h5 className="result-title">Maximo Incremento de Renta</h5>
-            {this.state.cpiSelection ? (
-              <h3>
-                {parseFloat((0.05 + parseFloat(this.state.cpi)) * 100).toFixed(
-                  2
+            <div className="card">
+              <div className="card-body">
+                <h5 className="card-title">Cual es su Codigo Postal?</h5>
+                <input
+                  className="form-control"
+                  type="text"
+                  onChange={e => this.setCpiFromZip(e)}
+                  placeholder="Los 5 digitos de su codigo postal (zip code)"
+                />
+                {this.state.town && (
+                  <small>
+                    <strong>{this.state.town}</strong>
+                    {this.state.county && (
+                      <strong>, Condado de {this.state.county}</strong>
+                    )}
+                  </small>
                 )}
-                %
-              </h3>
-            ) : (
-              <h3>-</h3>
-            )}
-            <small>
-              5% Base + {parseFloat(this.state.cpi * 100).toFixed(2)}% CPI
-            </small>
+                <br />
+                <br />
+                <br />
+                <h5>Cuanto estaba pagando de renta en o desde Marzo 15, 2019?</h5>
+                <div className="input-group mb-3">
+                  <div className="input-group-prepend">
+                    <span className="input-group-text">$</span>
+                  </div>
+                  <input
+                    type="number"
+                    className="form-control"
+                    value={this.state.pastRent}
+                    placeholder="Monto de renta"
+                    onChange={e => this.handlePastRentChange(e)}
+                  />
+                </div>
+              </div>
+            </div>
             <br />
-            <small>
-              <strong>
-                {this.state.cpiSelection ? this.state.cpiSelection : ""}
-              </strong>
+            <br />
+            <ul className="calculator-results">
+              <li>
+                <h5 className="result-title">Maximo Incremento de Renta</h5>
+                {this.state.cpiSelection ? (
+                  <h3>
+                    {parseFloat((0.05 + parseFloat(this.state.cpi)) * 100).toFixed(
+                      2
+                    )}
+                    %
+              </h3>
+                ) : (
+                    <h3>-</h3>
+                  )}
+                <small>
+                  5% Base + {parseFloat(this.state.cpi * 100).toFixed(2)}% CPI
             </small>
-          </li>
-          <li>
-            <h5 className="result-title">Monto de Renta Permitido</h5>
-            {maxRent > 0 && this.state.cpiSelection ? (
-              <h3>${maxRent}</h3>
-            ) : (
-              <h3>-</h3>
-            )}
-            <small>Comenzando el 1 de Enero del 2020</small>
-          </li>
-        </ul>
-        <Disclaimer />
-        <br />
-        <br />
-        {/* {this.state.showSection
+                <br />
+                <small>
+                  <strong>
+                    {this.state.cpiSelection ? this.state.cpiSelection : ""}
+                  </strong>
+                </small>
+              </li>
+              <li>
+                <h5 className="result-title">Monto de Renta Permitido</h5>
+                {maxRent > 0 && this.state.cpiSelection ? (
+                  <h3>${maxRent}</h3>
+                ) : (
+                    <h3>-</h3>
+                  )}
+                <small>Comenzando el 1 de Enero del 2020</small>
+              </li>
+            </ul>
+            <Disclaimer />
+            <br />
+            <br />
+            {/* {this.state.showSection
           ? (
             <h4>
               Enter your information below to determine how much money
@@ -382,39 +383,41 @@ class Calculator extends React.Component {
               Did your rent increase on or after January 1st, 2020?
             </PrimaryButton2>
           )} */}
-        <br />
-        {this.state.showSection && (
-          <section>
-            <div className="card">
-              <div className="card-body">
-                <h5 className="card-title">
-                  Ingrese su historial de renta desde el 1 de enero del 2020
-                  hasta ahora.
+            <br />
+            {this.state.showSection && (
+              <section>
+                <div className="card">
+                  <div className="card-body">
+                    <h5 className="card-title">
+                      Ingrese su historial de renta desde el 1 de enero del 2020
+                      hasta ahora.
                 </h5>
-                <section className="rent-increases">
-                  <ul>{rentRangeList}</ul>
-                  <SuccessButton className="add" onClick={this.addRentRange}>
-                    +
+                    <section className="rent-increases">
+                      <ul>{rentRangeList}</ul>
+                      <SuccessButton className="add" onClick={this.addRentRange}>
+                        +
                   </SuccessButton>
-                </section>
-              </div>
-            </div>
-            <br />
-            <h4 className="refund-information">
-              Según la información proporcionada, es posible que se le deban
+                    </section>
+                  </div>
+                </div>
+                <br />
+                <h4 className="refund-information">
+                  Según la información proporcionada, es posible que se le deban
             </h4>
-            <div className="refund-container">
-              <h1>${refund}</h1>
-              {refund > 0 && <ul>{refundBreakdown}</ul>}
-            </div>
-            <br />
-            {/* <PrimaryButton onClick={() => this.setState({showLetter: true})}>
+                <div className="refund-container">
+                  <h1>${refund}</h1>
+                  {refund > 0 && <ul>{refundBreakdown}</ul>}
+                </div>
+                <br />
+                {/* <PrimaryButton onClick={() => this.setState({showLetter: true})}>
             Generate a letter to your landlord</PrimaryButton> */}
-          </section>
-        )}
-        {/* {this.state.showLetter
+              </section>
+            )}
+            {/* {this.state.showLetter
           && <GenerateLetter />} */}
-      </div>
+          </div>
+        )}
+      </AppContext.Consumer>
     );
   }
 }

--- a/src/pages/es/eligibility/state/buildingAge.mdx
+++ b/src/pages/es/eligibility/state/buildingAge.mdx
@@ -1,15 +1,9 @@
 import YesNoMaybeState from  '../../../../components/clauses/YesNoMaybeState';
 
 <YesNoMaybeState
-<<<<<<< HEAD
   yes="/es/eligibility/state/sharedKitchenOrBath"
   no="/es/eligibility/state/coverage/notCovered"
   maybe="/es/eligibility/state/sharedKitchenOrBath"
-=======
-  yes="/es/eligibility/state/atLeast4Units"
-  no="/es/eligibility/state/coverage/notCovered"
-  maybe="/es/eligibility/state/atLeast4Units"
->>>>>>> make page and state names consistent
   questionText="¿Su edificio tiene al menos 15 años (fue construido antes de 2005)?"
   stateName="builtBefore2005"
 />

--- a/src/pages/es/eligibility/state/buildingAge.mdx
+++ b/src/pages/es/eligibility/state/buildingAge.mdx
@@ -1,9 +1,15 @@
 import YesNoMaybeState from  '../../../../components/clauses/YesNoMaybeState';
 
 <YesNoMaybeState
+<<<<<<< HEAD
   yes="/es/eligibility/state/sharedKitchenOrBath"
   no="/es/eligibility/state/coverage/notCovered"
   maybe="/es/eligibility/state/sharedKitchenOrBath"
+=======
+  yes="/es/eligibility/state/atLeast4Units"
+  no="/es/eligibility/state/coverage/notCovered"
+  maybe="/es/eligibility/state/atLeast4Units"
+>>>>>>> make page and state names consistent
   questionText="¿Su edificio tiene al menos 15 años (fue construido antes de 2005)?"
   stateName="builtBefore2005"
 />

--- a/src/pages/es/eligibility/state/coverage/covered.mdx
+++ b/src/pages/es/eligibility/state/coverage/covered.mdx
@@ -33,7 +33,7 @@ import { PrimaryButton } from "../../../../../components/Buttons";
             }
             <p>Recuerde que estos no son sus únicos derechos como inquilino, solo los cubiertos por AB-1482. Si tiene dudas o está preocupado por su situación de vida, comuníquese con el gobierno local de su ciudad o condado para obtener ayuda o con un grupo local de derechos de los inquilinos. Podemos conectarlo con ellos a continuación.</p>
             <h1>¿Tienes problemas con su renta?</h1>
-            <PrimaryButton to="/es/gethelp">¡Lo podemos ayudar!</PrimaryButton>
+            <PrimaryButton to="/es/getHelp">¡Lo podemos ayudar!</PrimaryButton>
         </div>
     )}
 </AppContext.Consumer>

--- a/src/pages/es/eligibility/state/coverage/notCovered.mdx
+++ b/src/pages/es/eligibility/state/coverage/notCovered.mdx
@@ -28,4 +28,4 @@ import { PrimaryButton } from "../../../../../components/Buttons";
 </AppContext.Consumer>
 
 ## ¿Tiene problemas con su arrendador?
-<PrimaryButton to="/es/gethelp">¡Lo podemos ayudar!</PrimaryButton>
+<PrimaryButton to="/es/getHelp">¡Lo podemos ayudar!</PrimaryButton>

--- a/src/pages/es/getHelp.mdx
+++ b/src/pages/es/getHelp.mdx
@@ -1,0 +1,7 @@
+import ContactForm from "../../components/Contact";
+import { QuickContactForm, FullContactForm } from "../../components/Contact";
+
+# Connect with us
+Need help with your tenancy? Let us connect you with local non-profit groups who may be able to help you with your situatation.
+
+<QuickContactForm submitDestination="/getHelpSubmit" />

--- a/src/pages/es/gethelp-test.mdx
+++ b/src/pages/es/gethelp-test.mdx
@@ -1,5 +1,5 @@
-import ContactForm from "../components/Contact";
-import { QuickContactForm, FullContactForm } from "../components/Contact";
+import ContactForm from "../../components/Contact";
+import { QuickContactForm, FullContactForm } from "../../components/Contact";
 
 
 # Quick Contact Form

--- a/src/pages/getHelp.mdx
+++ b/src/pages/getHelp.mdx
@@ -1,0 +1,7 @@
+import ContactForm from "../components/Contact";
+import { QuickContactForm, FullContactForm } from "../components/Contact";
+
+# Connect with us
+Need help with your tenancy? Let us connect you with local non-profit groups who may be able to help you with your situatation.
+
+<QuickContactForm submitDestination="/getHelpSubmit" />

--- a/src/pages/getHelpSubmit.mdx
+++ b/src/pages/getHelpSubmit.mdx
@@ -1,0 +1,5 @@
+import ContactForm from "../components/Contact";
+import { QuickContactForm, FullContactForm } from "../components/Contact";
+
+# Thanks for connecting with us
+One of our local non-profits will be in touch soon to talk to you about your situation. In the meantime why not check out out our [resources page](/resources) for more ways to get help. 

--- a/src/pages/getHelpSubmit.mdx
+++ b/src/pages/getHelpSubmit.mdx
@@ -1,5 +1,8 @@
 import ContactForm from "../components/Contact";
 import { QuickContactForm, FullContactForm } from "../components/Contact";
+import AutoSubmit from "../components/AutoSubmit";
 
 # Thanks for connecting with us
 One of our local non-profits will be in touch soon to talk to you about your situation. In the meantime why not check out out our [resources page](/resources) for more ways to get help. 
+
+<AutoSubmit pageName="getHelpSubmit" />

--- a/src/pages/gethelp-test.mdx
+++ b/src/pages/gethelp-test.mdx
@@ -1,9 +1,11 @@
 import ContactForm from "../components/contactACCE";
 import { QuickContactForm, FullContactForm } from "../components/contactACCE";
 
+
+# Quick Contact Form
+This form is the short form for use at the front of flows and self-hides after submissions.
 <ContactForm />
-<QuickContactForm />
-<FullContactForm />
+<hr />
 
 <form name="contact" netlify netlify-honeypot="bot-field" hidden>
   <input type="hidden" name="quickForm" value="testQuickContact" />
@@ -12,6 +14,12 @@ import { QuickContactForm, FullContactForm } from "../components/contactACCE";
   <input type="tel" name="cell" />
   <input type="email" name="email" />
 </form>
+
+# Full Contact Form
+This form is the fuller form for use at the end of flows or on the "Get Help" page. If you filled in a flow or the calculator it provides the option to share those answers with ACCE
+<hr />
+<FullContactForm />
+
 
 <form name="contact" netlify netlify-honeypot="bot-field" hidden>
   <input type="hidden" name="fullForm" value="testFullContact" />

--- a/src/pages/gethelp-test.mdx
+++ b/src/pages/gethelp-test.mdx
@@ -19,23 +19,3 @@ This form is the short form for use at the front of flows and self-hides after s
 This form is the fuller form for use at the end of flows or on the "Get Help" page. If you filled in a flow or the calculator it provides the option to share those answers with ACCE
 <hr />
 <FullContactForm />
-
-
-  <form name="contact" netlify netlify-honeypot="bot-field" hidden>
-  <input type="hidden" name="form-name" value="testFullContact" />
-  <input type="hidden" name="form-name" value="testFullContact" />
-  <input type="text" name="givenName"  />
-  <input type="text" name="familyName"  />      
-  <input type="tel" name="cell"/>
-  <input type="email" name="email" />
-  <input type="checkbox" name="rentIncrease" />
-  <input type="checkbox" name="rentIncrease"  />
-  <input type="checkbox" name="rentIncrease"  />
-  <input type="checkbox" name="eviction"  />
-  <input type="checkbox" name="landlordOther"  />
-  <input type="checkbox" name="understandRights"  />
-  <input type="checkbox" name="fightForRights"  />
-  <input type="checkbox" name="contactCall" />
-  <input type="checkbox" name="contactTxt"  />
-  <input type="checkbox" name="contactEmail" />
-</form>

--- a/src/pages/gethelp-test.mdx
+++ b/src/pages/gethelp-test.mdx
@@ -7,14 +7,6 @@ This form is the short form for use at the front of flows and self-hides after s
 <ContactForm />
 <hr />
 
-<form name="contact" netlify netlify-honeypot="bot-field" hidden>
-  <input type="hidden" name="form-name" value="testQuickContact" />
-  <input type="text" name="givenName" />
-  <input type="text" name="familyName" />
-  <input type="tel" name="cell" />
-  <input type="email" name="email" />
-</form>
-
 # Full Contact Form
 This form is the fuller form for use at the end of flows or on the "Get Help" page. If you filled in a flow or the calculator it provides the option to share those answers with ACCE
 <hr />

--- a/src/pages/gethelp-test.mdx
+++ b/src/pages/gethelp-test.mdx
@@ -1,10 +1,27 @@
 import ContactForm from "../components/contactACCE";
+import { QuickContactForm, FullContactForm } from "../components/contactACCE";
 
 <ContactForm />
+<QuickContactForm />
+<FullContactForm />
 
 <form name="contact" netlify netlify-honeypot="bot-field" hidden>
-  <input type="hidden" name="form-name" value="testContact" />
-  <input type="text" name="name" />
+  <input type="hidden" name="quickForm" value="testQuickContact" />
+  <input type="text" name="givenName" />
+  <input type="text" name="familyName" />
+  <input type="tel" name="cell" />
   <input type="email" name="email" />
-  <textarea name="message"></textarea>
+</form>
+
+<form name="contact" netlify netlify-honeypot="bot-field" hidden>
+  <input type="hidden" name="fullForm" value="testFullContact" />
+  <input type="text" name="givenName" />
+  <input type="text" name="familyName" />
+  <input type="tel" name="cell" />
+  <input type="email" name="email" />
+  <input type="checkbox" name="rentIncrease" />
+  <input type="checkbox" name="eviction" />
+  <input type="checkbox" name="landlordOther" />
+  <input type="checkbox" name="understandRights" />
+  <input type="checkbox" name="fightForRights" />
 </form>

--- a/src/pages/gethelp-test.mdx
+++ b/src/pages/gethelp-test.mdx
@@ -8,7 +8,7 @@ This form is the short form for use at the front of flows and self-hides after s
 <hr />
 
 <form name="contact" netlify netlify-honeypot="bot-field" hidden>
-  <input type="hidden" name="quickForm" value="testQuickContact" />
+  <input type="hidden" name="form-name" value="testQuickContact" />
   <input type="text" name="givenName" />
   <input type="text" name="familyName" />
   <input type="tel" name="cell" />
@@ -21,15 +21,21 @@ This form is the fuller form for use at the end of flows or on the "Get Help" pa
 <FullContactForm />
 
 
-<form name="contact" netlify netlify-honeypot="bot-field" hidden>
-  <input type="hidden" name="fullForm" value="testFullContact" />
-  <input type="text" name="givenName" />
-  <input type="text" name="familyName" />
-  <input type="tel" name="cell" />
+  <form name="contact" netlify netlify-honeypot="bot-field" hidden>
+  <input type="hidden" name="form-name" value="testFullContact" />
+  <input type="hidden" name="form-name" value="testFullContact" />
+  <input type="text" name="givenName"  />
+  <input type="text" name="familyName"  />      
+  <input type="tel" name="cell"/>
   <input type="email" name="email" />
   <input type="checkbox" name="rentIncrease" />
-  <input type="checkbox" name="eviction" />
-  <input type="checkbox" name="landlordOther" />
-  <input type="checkbox" name="understandRights" />
-  <input type="checkbox" name="fightForRights" />
+  <input type="checkbox" name="rentIncrease"  />
+  <input type="checkbox" name="rentIncrease"  />
+  <input type="checkbox" name="eviction"  />
+  <input type="checkbox" name="landlordOther"  />
+  <input type="checkbox" name="understandRights"  />
+  <input type="checkbox" name="fightForRights"  />
+  <input type="checkbox" name="contactCall" />
+  <input type="checkbox" name="contactTxt"  />
+  <input type="checkbox" name="contactEmail" />
 </form>

--- a/src/styles/contact.scss
+++ b/src/styles/contact.scss
@@ -1,0 +1,16 @@
+input.form-control {
+    margin: 0.35em 0.35em 0 0;
+    display: inline-block;
+    width: auto;
+}
+
+label.form-control {
+    width: auto;
+    height: auto;
+    border: 1px solid #acacac;
+    display: inline-block;
+}
+
+.disclaimer {
+    font-size: 0.8rem;
+}

--- a/src/styles/typography.scss
+++ b/src/styles/typography.scss
@@ -144,6 +144,7 @@ button:-moz-focusring {
 fieldset {
   border: 1px solid silver;
   margin: 0 2px;
+  margin-top: 0.5em !important;
   padding: 0.35em 0.625em 0.75em;
 }
 legend {
@@ -151,8 +152,13 @@ legend {
   color: inherit;
   display: table;
   max-width: 100%;
-  padding: 0;
+  margin-top: 0.35em;
+  padding: 0.35em 0;
   white-space: normal;
+  font-family: "Varela Round", sans-serif;
+  font-weight: 400;
+  text-rendering: optimizeLegibility;
+  font-size: 20px !important;
 }
 textarea {
   overflow: auto;

--- a/src/templates/county-es.js
+++ b/src/templates/county-es.js
@@ -28,7 +28,7 @@ const County = () => {
             Puede comunicarse con estos recursos útiles en {appCtx.county} para
             determinar si es elegible.
           </p>
-          <PrimaryButton to="/es/gethelp">
+          <PrimaryButton to="/es/resources">
             Obtenga ayuda de un grupo adecuado de inquilinos locales.
           </PrimaryButton>
 

--- a/src/templates/county.js
+++ b/src/templates/county.js
@@ -13,7 +13,7 @@ const County = () => {
                     <p>Since {appCtx.county } county has some protections we want to figure out if you are eligible for those protections provided by { appCtx.county } county law. If those don't apply the state-wide protections in AB1482 may still apply to you.</p>
 
                     <p>You can reach out to these great resources in { appCtx.county } county to figure out if you are eligible.</p>
-                    <PrimaryButton to="/gethelp">Get help from a local tenants right group!</PrimaryButton>
+                    <PrimaryButton to="/getHelp">Get help from a local tenants right group!</PrimaryButton>
                     
 
                     <p><br />Do you get rent control in { appCtx.county } county?</p>


### PR DESCRIPTION
Working on some better components for contact forms. I made 2 versions, I'm probably going to refactor a bit later to DRY them out.

**QuickContactForm**
This one is to embed in the front of flows such as eligibility and the calculator and hides after submit.
**FullContactForm**
This is the fuller form to use from `/getHelp` and has a few more inputs and includes the option to submit answers from the web site which is a WIP.

You can play with the test forms at: https://deploy-preview-83--tenant-protections.netlify.com/gethelp-test/

## TODOs
- [x] Styling currently sucks
- [x] Testing submit works correctly with netlify
- [x] Integrating QuickContact into the calculator
- [x] Integrating QuickContact into the eligibilty flow
- [x] Integrating FullContact into `/getHelp`
- [x] Migrating links to point from `/resources` to `getHelp`  for contact
- [x] Blurbs / copy for these pages
- [x] Saving answers onto state to prefill later
- [ ] Coming up with a decent way "amend" answers on the backend. Currently I'm just planning to let people submit multiple different form entries and leave it to ACCE to de-dupe and avoid bugging people.
- [ ] Finish wiring up translations properly
- [ ] Hook up Google sheets via Zapier

## Things others could really help with
- [ ] Design for these pages
- [ ] Styling for these form elements (feel free to change the markup as needed)
- [ ] Some copy / blurb about contacting ACCE and getting free legal support (or where people wouldn't get free legal support if that's the case
- [ ] Translations to Spanish (@hborrego)